### PR TITLE
Swapped order of comparison

### DIFF
--- a/extensions/_modules/testinframod.py
+++ b/extensions/_modules/testinframod.py
@@ -146,7 +146,7 @@ def _apply_assertion(expected, result):
     elif isinstance(expected, dict):
         try:
             return getattr(operator, expected['comparison'])(
-                expected['expected'], result)
+                result, expected['expected'])
         except KeyError:
             log.exception('The comparison dictionary provided is missing '
                           'expected keys. Either "expected" or "comparison" '


### PR DESCRIPTION
Swapped the order of comparison when calling operator functions. This is
to allow for using the `contains` operator, as well as making the
ordering more intuitive. This now means that when using `lt` (<),
`gt` (>), etc. then the comparison looks like:

`lt` = `result` < `expected`

So, when using a block that looks like:

``` yaml
testinfra.user:
  - name: username
  - uid:
      expected: 1000
      comparison: lt
```

then it will evaluate to `True` if the result is less than 1000.
