### PR TITLE
Patched version of boto_rds from carbon release

### DIFF
--- a/extensions/_modules/boto_rds.py
+++ b/extensions/_modules/boto_rds.py
@@ -1,0 +1,888 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon RDS
+
+.. versionadded:: 2015.8.0
+
+:configuration: This module accepts explicit rds credentials but can also
+    utilize IAM roles assigned to the instance through Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at:
+
+    .. code-block:: text
+
+        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+    .. code-block:: yaml
+
+        rds.keyid: GKTADJGHEIQSXMKKRBJ08H
+        rds.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration:
+
+    .. code-block:: yaml
+
+        rds.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+    .. code-block:: yaml
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto3
+'''
+# keep lint from choking on _get_conn and _cache_id
+#pylint: disable=E0602
+
+
+# Import Python libs
+from __future__ import absolute_import
+import logging
+from salt.exceptions import SaltInvocationError
+from distutils.version import LooseVersion as _LooseVersion  # pylint: disable=import-error,no-name-in-module
+from time import time, sleep
+
+# Import Salt libs
+import salt.utils.boto3
+import salt.utils.compat
+import salt.utils.odict as odict
+import salt.utils
+import salt.ext.six as six
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+# pylint: disable=import-error
+try:
+    #pylint: disable=unused-import
+    import boto
+    import boto3
+    #pylint: enable=unused-import
+    from botocore.exceptions import ClientError
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    logging.getLogger('boto3').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+# pylint: enable=import-error
+
+boto3_param_map = {
+    'allocated_storage': ('AllocatedStorage', lambda val: int(val)),
+    'allow_major_version_upgrade': ('AllowMajorVersionUpgrade', lambda val: bool(val)),
+    'auto_minor_version_upgrade': ('AutoMinorVersionUpgrade', lambda val: bool(val)),
+    'availability_zone': ('AvailabilityZone', lambda val: str(val)),
+    'apply_immediately': ('ApplyImmediately', lambda val: bool(val)),
+    'backup_retention_period': ('BackupRetentionPeriod', lambda val: int(val)),
+    'ca_certificate_identifier': ('CACertificateIdentifier', lambda val: str(val)),
+    'character_set_name': ('CharacterSetName', lambda val: str(val)),
+    'copy_tags_to_snapshot': ('CopyTagsToSnapshot', lambda val: bool(val)),
+    'db_cluster_identifier': ('DBClusterIdentifier', lambda val: str(val)),
+    'db_instance_class': ('DBInstanceClass', lambda val: str(val)),
+    'db_name': ('DBName', lambda val: str(val)),
+    'db_parameter_group_name': ('DBParameterGroupName', lambda val: str(val)),
+    'db_port_number': ('DBPortNumber', lambda val: int(val)),
+    'db_security_groups': ('DBSecurityGroups', lambda val: list(val)),
+    'db_subnet_group_name': ('DBSubnetGroupName', lambda val: str(val)),
+    'db_cluster_identifier': ('DBClusterIdentifier', lambda val: str(val)),
+    'domain': ('Domain', lambda val: str(val)),
+    'domain_iam_role_name': ('DomainIAMRoleName', lambda val: str(val)),
+    'engine': ('Engine', lambda val: str(val)),
+    'engine_version': ('EngineVersion', lambda val: str(val)),
+    'iops': ('Iops', lambda val: int(val)),
+    'kms_key_id': ('KmsKeyId', lambda val: str(val)),
+    'license_model': ('LicenseModel', lambda val: str(val)),
+    'master_user_password': ('MasterUserPassword', lambda val: str(val)),
+    'master_username': ('MasterUsername', lambda val: str(val)),
+    'monitoring_interval': ('MonitoringInterval', lambda val: int(val)),
+    'monitoring_role_arn': ('MonitoringRoleArn', lambda val: str(val)),
+    'multi_az': ('MultiAZ', lambda val: bool(val)),
+    'name': ('DBInstanceIdentifier', lambda val: str(val)),
+    'new_db_instance_identifier': ('NewDBInstanceIdentifier', lambda val: str(val)),
+    'option_group_name': ('OptionGroupName', lambda val: str(val)),
+    'port': ('Port', lambda val: int(val)),
+    'preferred_backup_window': ('PreferredBackupWindow', lambda val: str(val)),
+    'preferred_maintenance_window': ('PreferredMaintenanceWindow', lambda val: str(val)),
+    'promotion_tier': ('PromotionTier', lambda val: int(val)),
+    'publicly_accessible': ('PubliclyAccessible', lambda val: bool(val)),
+    'storage_encrypted': ('StorageEncrypted', lambda val: bool(val)),
+    'storage_type': ('StorageType', lambda val: str(val)),
+    'taglist': ('Tags', lambda val: list(val)),
+    'tde_credential_arn': ('TdeCredentialArn', lambda val: str(val)),
+    'tde_credential_password': ('TdeCredentialPassword', lambda val: str(val)),
+    'vpc_security_group_ids': ('VpcSecurityGroupIds', lambda val: list(val)),
+}
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist and if boto libraries are greater than
+    a given version.
+    '''
+    required_boto3_version = '1.3.1'
+    if not HAS_BOTO:
+        return (False, 'The boto_rds module could not be loaded: '
+                'boto libraries not found')
+    elif _LooseVersion(boto3.__version__) < _LooseVersion(required_boto3_version):
+        return (False, 'The boto_rds module could not be loaded: '
+                'boto version {0} or later must be installed.'.format(required_boto3_version))
+    else:
+        return True
+
+
+def __init__(opts):
+    salt.utils.compat.pack_dunder(__name__)
+    if HAS_BOTO:
+        __utils__['boto3.assign_funcs'](__name__, 'rds')
+
+
+def exists(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if an RDS exists.
+
+    CLI example::
+
+        salt myminion boto_rds.exists myrds region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def option_group_exists(name, tags=None, region=None, key=None, keyid=None,
+                        profile=None):
+    '''
+    Check to see if an RDS option group exists.
+
+    CLI example::
+
+        salt myminion boto_rds.option_group_exists myoptiongr region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        rds = conn.describe_option_groups(OptionGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def parameter_group_exists(name, tags=None, region=None, key=None, keyid=None,
+                           profile=None):
+    '''
+    Check to see if an RDS parameter group exists.
+
+    CLI example::
+
+        salt myminion boto_rds.parameter_group_exists myparametergroup \
+                region=us-east-1
+    '''
+    conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+
+    try:
+        rds = conn.describe_db_parameter_groups(DBParameterGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def subnet_group_exists(name, tags=None, region=None, key=None, keyid=None,
+                        profile=None):
+    '''
+    Check to see if an RDS subnet group exists.
+
+    CLI example::
+
+        salt myminion boto_rds.subnet_group_exists my-param-group \
+                region=us-east-1
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'exists': bool(conn)}
+
+        rds = conn.describe_db_subnet_groups(DBSubnetGroupName=name)
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create(name, allocated_storage, db_instance_class, engine,
+           master_username, master_user_password, db_name=none,
+           db_security_groups=None, vpc_security_group_ids=None,
+           availability_zone=None, db_subnet_group_name=None,
+           preferred_maintenance_window=None, db_parameter_group_name=None,
+           backup_retention_period=None, preferred_backup_window=None,
+           port=None, multi_az=None, engine_version=None,
+           auto_minor_version_upgrade=None, license_model=None, iops=None,
+           option_group_name=None, character_set_name=None,
+           publicly_accessible=None, wait_status=None, tags=None,
+           db_cluster_identifier=None, storage_type=None,
+           tde_credential_arn=None, tde_credential_password=None,
+           storage_encrypted=None, kms_key_id=None, domain=None,
+           copy_tags_to_snapshot=None, monitoring_interval=none,
+           monitoring_role_arn=None, domain_iam_role_name=None, region=None,
+           promotion_tier=None, key=None, keyid=None, profile=None):
+    '''
+    Create an RDS
+
+    CLI example to create an RDS::
+
+        salt myminion boto_rds.create myrds 10 db.t2.micro MySQL sqlusr sqlpassw
+    '''
+    if not allocated_storage:
+        raise SaltInvocationError('allocated_storage is required')
+    if not db_instance_class:
+        raise SaltInvocationError('db_instance_class is required')
+    if not engine:
+        raise SaltInvocationError('engine is required')
+    if not master_username:
+        raise SaltInvocationError('master_username is required')
+    if not master_user_password:
+        raise SaltInvocationError('master_user_password is required')
+    if availability_zone and MultiAZ:
+        raise SaltInvocationError('availability_zone and multi_az are mutually'
+                                  ' exclusive arguments.')
+    if wait_status:
+        wait_statuses = ['available', 'modifying', 'backing-up']
+        if wait_status not in wait_statuses:
+            raise SaltInvocationError('wait_status can be one of: '
+                                      '{0}'.format(wait_statuses))
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        kwargs = {}
+        excluded = {'region', 'key', 'keyid', 'profile', 'tags'}
+        keys = set(locals().keys())
+        for key in keys.difference(excluded):
+            val = locals()[key]
+            if val is not None:
+                mapped = boto3_param_map[key]
+                kwargs[mapped[0]] = mapped[1](val)
+
+        taglist = _tag_doc(tags)
+
+        # Validation doesn't want parameters that are None
+        # https://github.com/boto/boto3/issues/400
+        kwargs = dict((k, v) for k, v in six.iteritems(kwargs) if v is not None)
+
+        rds = conn.create_db_instance(**kwargs)
+
+        if not rds:
+            return {'created': False}
+        if not wait_status:
+            return {'created': True, 'message':
+                    'Created RDS instance {0}.'.format(name)}
+
+        while True:
+            log.info('Waiting 10 secs...')
+            sleep(10)
+            _describe = describe(name=name, tags=tags, region=region, key=key,
+                                 keyid=keyid, profile=profile)['rds']
+            if not _describe:
+                return {'created': True}
+            if _describe['DBInstanceStatus'] == wait_status:
+                return {'created': True, 'message':
+                        'Created RDS {0} with current status '
+                        '{1}'.format(name, _describe['DBInstanceStatus'])}
+
+            log.info('Current status: {0}'.format(_describe['DBInstanceStatus']))
+
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_read_replica(name, source_name, db_instance_class=None,
+                        availability_zone=None, port=None,
+                        auto_minor_version_upgrade=None, iops=None,
+                        option_group_name=None, publicly_accessible=None,
+                        tags=None, db_subnet_group_name=None,
+                        storage_type=None, copy_tags_to_snapshot=None,
+                        monitoring_interval=None, monitoring_role_arn=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Create an RDS read replica
+
+    CLI example to create an RDS  read replica::
+
+        salt myminion boto_rds.create_read_replica replicaname source_name
+    '''
+    if not backup_retention_period:
+        raise SaltInvocationError('backup_retention_period is required')
+    res = __salt__['boto_rds.exists'](source_name, tags, region, key, keyid, profile)
+    if not res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS instance source {0} does not exists.'.format(source_name)}
+
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS replica instance {0} already exists.'.format(name)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        kwargs = {}
+        for key in ('OptionGroupName', 'MonitoringRoleArn'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        for key in ('MonitoringInterval', 'Iops', 'Port'):
+            if locals()[key] is not None:
+                kwargs[key] = int(locals()[key])
+
+        for key in ('CopyTagsToSnapshot', 'AutoMinorVersionUpgrade'):
+            if locals()[key] is not None:
+                kwargs[key] = bool(locals()[key])
+
+        taglist = _tag_doc(tags)
+
+        rds_replica = conn.create_db_instance_read_replica(DBInstanceIdentifier=name,
+                                                           SourceDBInstanceIdentifier=source_name,
+                                                           DBInstanceClass=db_instance_class,
+                                                           AvailabilityZone=availability_zone,
+                                                           PubliclyAccessible=publicly_accessible,
+                                                           Tags=taglist, DBSubnetGroupName=db_subnet_group_name,
+                                                           StorageType=storage_type,
+                                                           **kwargs)
+
+        return {'exists': bool(rds_replica)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_option_group(name, engine_name, major_engine_version,
+                        option_group_description, tags=None, region=None,
+                        key=None, keyid=None, profile=None):
+    '''
+    Create an RDS option group
+
+    CLI example to create an RDS option group::
+
+        salt myminion boto_rds.create_option_group my-opt-group mysql 5.6 \
+                "group description"
+    '''
+    res = __salt__['boto_rds.option_group_exists'](name, tags, region, key, keyid,
+                                                   profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_option_group(OptionGroupName=name,
+                                       EngineName=engine_name,
+                                       MajorEngineVersion=major_engine_version,
+                                       OptionGroupDescription=option_group_description,
+                                       Tags=taglist)
+
+        return {'exists': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_parameter_group(name, db_parameter_group_family, description,
+                           tags=None, region=None, key=None, keyid=None,
+                           profile=None):
+    '''
+    Create an RDS parameter group
+
+    CLI example to create an RDS parameter group::
+
+        salt myminion boto_rds.create_parameter_group my-param-group mysql5.6 \
+                "group description"
+    '''
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
+                                                      keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_db_parameter_group(DBParameterGroupName=name,
+                                             DBParameterGroupFamily=db_parameter_group_family,
+                                             Description=description,
+                                             Tags=taglist)
+        if not rds:
+            return {'created': False, 'message':
+                    'Failed to create RDS parameter group {0}'.format(name)}
+
+        return {'exists': bool(rds), 'message':
+                'Created RDS parameter group {0}'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def create_subnet_group(name, description, subnet_ids, tags=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Create an RDS subnet group
+
+    CLI example to create an RDS subnet group::
+
+        salt myminion boto_rds.create_subnet_group my-subnet-group \
+            "group description" '[subnet-12345678, subnet-87654321]' \
+            region=us-east-1
+    '''
+    res = __salt__['boto_rds.subnet_group_exists'](name, tags, region, key,
+                                                 keyid, profile)
+    if res.get('exists'):
+        return {'exists': bool(res)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        taglist = _tag_doc(tags)
+        rds = conn.create_db_subnet_group(DBSubnetGroupName=name,
+                                          DBSubnetGroupDescription=description,
+                                          SubnetIds=subnet_ids, Tags=taglist)
+
+        return {'created': bool(rds)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def update_parameter_group(name, parameters, apply_method="pending-reboot",
+                           tags=None, region=None, key=None, keyid=None,
+                           profile=None):
+    '''
+    Update an RDS parameter group.
+
+    CLI example::
+
+        salt myminion boto_rds.update_parameter_group my-param-group \
+                parameters='{"back_log":1, "binlog_cache_size":4096}' \
+                region=us-east-1
+    '''
+
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags, region, key,
+                                                      keyid, profile)
+    if not res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS parameter group {0} does not exist.'.format(name)}
+
+    param_list = []
+    for key, value in six.iteritems(parameters):
+        item = (key, value, apply_method)
+        param_list.append(item)
+        if not len(param_list):
+            return {'results': False}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        res = conn.modify_db_parameter_group(DBParameterGroupName=name,
+                                             Parameters=param_list)
+        return {'results': bool(res)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def describe(name, tags=None, region=None, key=None, keyid=None,
+             profile=None):
+    '''
+    Return RDS instance details.
+
+    CLI example::
+
+        salt myminion boto_rds.describe myrds
+
+    '''
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
+                                      profile)
+    if not res.get('exists'):
+        return {'exists': bool(res), 'message':
+                'RDS instance {0} does not exist.'.format(name)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+
+        if rds:
+            keys = ('DBInstanceIdentifier', 'DBInstanceClass', 'Engine',
+                    'DBInstanceStatus', 'DBName', 'AllocatedStorage',
+                    'PreferredBackupWindow', 'BackupRetentionPeriod',
+                    'AvailabilityZone', 'PreferredMaintenanceWindow',
+                    'LatestRestorableTime', 'EngineVersion',
+                    'AutoMinorVersionUpgrade', 'LicenseModel',
+                    'Iops', 'CharacterSetName', 'PubliclyAccessible',
+                    'StorageType', 'TdeCredentialArn', 'DBInstancePort',
+                    'DBClusterIdentifier', 'StorageEncrypted', 'KmsKeyId',
+                    'DbiResourceId', 'CACertificateIdentifier',
+                    'CopyTagsToSnapshot', 'MonitoringInterval',
+                    'MonitoringRoleArn', 'PromotionTier',
+                    'DomainMemberships')
+            return {'rds': dict([(k, rds.get('DBInstances', [{}])[0].get(k)) for k in keys])}
+        else:
+            return {'rds': None}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def get_endpoint(name, tags=None, region=None, key=None, keyid=None,
+                 profile=None):
+    '''
+    Return the endpoint of an RDS instance.
+
+    CLI example::
+
+        salt myminion boto_rds.get_endpoint myrds
+
+    '''
+    endpoint = 'None'
+    res = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
+                                      profile)
+    if not res:
+        return {'exists': bool(res), 'message':
+                'RDS instance {0} does not exist.'.format(name)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        rds = conn.describe_db_instances(DBInstanceIdentifier=name)
+
+        if rds:
+            inst = rds['DBInstances'][0]['Endpoint']
+            endpoint = '{0}:{1}'.format(inst.get('Address'), inst.get('Port'))
+            return endpoint
+
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def delete(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
+           region=None, key=None, keyid=None, profile=None,
+           wait_for_deletion=True, timeout=180):
+    '''
+    Delete an RDS instance.
+
+    CLI example::
+
+        salt myminion boto_rds.delete myrds skip_final_snapshot=True \
+                region=us-east-1
+    '''
+    if timeout == 180 and not skip_final_snapshot:
+        timeout = 420
+
+    if not skip_final_snapshot and not final_db_snapshot_identifier:
+        raise SaltInvocationError('At least one of the following must'
+                                  ' be specified: skip_final_snapshot'
+                                  ' final_db_snapshot_identifier')
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'deleted': bool(conn)}
+
+        kwargs = {}
+        if locals()['skip_final_snapshot'] is not None:
+            kwargs['SkipFinalSnapshot'] = bool(locals()['skip_final_snapshot'])
+
+        if locals()['final_db_snapshot_identifier'] is not None:
+            kwargs['FinalDBSnapshotIdentifier'] = str(locals()['final_db_snapshot_identifier'])
+
+        res = conn.delete_db_instance(DBInstanceIdentifier=name, **kwargs)
+
+        if not wait_for_deletion:
+            return {'deleted': bool(res), 'message':
+                    'Deleted RDS instance {0}.'.format(name)}
+
+        start_time = time()
+        while True:
+            if not __salt__['boto_rds.exists'](name=name, region=region,
+                                               key=key, keyid=keyid,
+                                               profile=profile):
+
+                return {'deleted': bool(res), 'message':
+                        'Deleted RDS instance {0} completely.'.format(name)}
+
+            if time() - start_time > timeout:
+                raise SaltInvocationError('RDS instance {0} has not been '
+                                          'deleted completely after {1} '
+                                          'seconds'.format(name, timeout))
+            sleep(10)
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_option_group(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete an RDS option group.
+
+    CLI example::
+
+        salt myminion boto_rds.delete_option_group my-opt-group \
+                region=us-east-1
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'deleted': bool(conn)}
+
+        res = conn.delete_option_group(OptionGroupName=name)
+        if not res:
+            return {'deleted': bool(res), 'message':
+                    'Failed to delete RDS option group {0}.'.format(name)}
+
+        return {'deleted': bool(res), 'message':
+                'Deleted RDS option group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_parameter_group(name, region=None, key=None, keyid=None,
+                           profile=None):
+    '''
+    Delete an RDS parameter group.
+
+    CLI example::
+
+        salt myminion boto_rds.delete_parameter_group my-param-group \
+                region=us-east-1
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        r = conn.delete_db_parameter_group(DBParameterGroupName=name)
+        return {'deleted': bool(r), 'message':
+                'Deleted RDS parameter group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def delete_subnet_group(name, region=None, key=None, keyid=None,
+                        profile=None):
+    '''
+    Delete an RDS subnet group.
+
+    CLI example::
+
+        salt myminion boto_rds.delete_subnet_group my-subnet-group \
+                region=us-east-1
+    '''
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        r = conn.delete_db_subnet_group(DBSubnetGroupName=name)
+        return {'deleted': bool(r), 'message':
+                'Deleted RDS subnet group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def describe_parameter_group(name, Filters=None, MaxRecords=None, Marker=None,
+                             region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns a list of `DBParameterGroup` descriptions.
+    CLI example to description of parameter group::
+
+        salt myminion boto_rds.describe_parameter_group parametergroupname\
+            region=us-east-1
+    '''
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags=None,
+                                                      region=region, key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+    if not res:
+        return {'exists': bool(res)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        kwargs = {}
+        for key in ('Marker', 'Filters'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        if locals()['MaxRecords'] is not None:
+            kwargs['MaxRecords'] = int(locals()['MaxRecords'])
+
+        info = conn.describe_db_parameter_groups(DBParameterGroupName=name,
+                                                 **kwargs)
+
+        if not info:
+            return {'results': bool(info), 'message':
+                    'Failed to get RDS description for group {0}.'.format(name)}
+
+        return {'results': bool(info), 'message':
+                'Got RDS descrition for group {0}.'.format(name)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def describe_parameters(name, Source=None, MaxRecords=None, Marker=None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Returns a list of `DBParameterGroup` parameters.
+    CLI example to description of parameters ::
+
+        salt myminion boto_rds.describe_parameters parametergroupname\
+            region=us-east-1
+    '''
+    res = __salt__['boto_rds.parameter_group_exists'](name, tags=None,
+                                                      region=region, key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+    if not res:
+        return {'exists': bool(res)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'results': bool(conn)}
+
+        kwargs = {}
+        for key in ('Marker', 'Source'):
+            if locals()[key] is not None:
+                kwargs[key] = str(locals()[key])
+
+        if locals()['MaxRecords'] is not None:
+            kwargs['MaxRecords'] = int(locals()['MaxRecords'])
+
+        r = conn.describe_db_parameters(DBParameterGroupName=name, **kwargs)
+
+        if not r:
+            return {'results': bool(r), 'message':
+                    'Failed to get RDS parameters for group {0}.'.format(name)}
+
+        results = r['Parameters']
+        keys = ['ParameterName', 'ParameterValue', 'Description',
+                'Source', 'ApplyType', 'DataType', 'AllowedValues',
+                'IsModifieable', 'MinimumEngineVersion', 'ApplyMethod']
+
+        c = 0
+        p = odict.OrderedDict()
+        while c < len(results):
+            d = odict.OrderedDict()
+            for k in keys:
+                d[k] = results[c].get(k)
+
+            p[results[c].get('ParameterName')] = d
+            c += 1
+
+        return p
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def modify_db_instance(name,
+                       allocated_storage=None,
+                       allow_major_version_upgrade=None,
+                       apply_immediately=None,
+                       auto_minor_version_upgrade=None,
+                       backup_retention_period=None,
+                       ca_certificate_identifier=None
+                       character_set_name=None,
+                       copy_tags_to_snapshot=None,
+                       db_cluster_identifier=None,
+                       db_instance_class=None,
+                       db_name=None,
+                       db_parameter_group_name=None,
+                       db_port_number=None,
+                       db_security_groups=None,
+                       db_subnet_group_name=None,
+                       db_cluster_identifier=None,
+                       domain=None,
+                       domain_iam_role_name=None,
+                       engine_version=None,
+                       iops=None,
+                       kms_key_id=None,
+                       license_model=None,
+                       master_user_password=None,
+                       monitoring_interval=None,
+                       monitoring_role_arn=None,
+                       multi_az=None,
+                       new_db_instance_identifier=None,
+                       option_group_name=None,
+                       preferred_backup_window=None,
+                       preferred_maintenance_window=None,
+                       promotion_tier=None,
+                       publicly_accessible=None,
+                       storage_encrypted=None,
+                       storage_type=None,
+                       tde_credential_arn=None,
+                       tde_credential_password=None,
+                       vpc_security_group_ids=None,
+                       region=None, key=None, keyid=None, profile=None):
+    '''
+    Modify settings for a DB instance.
+    CLI example to description of parameters ::
+
+        salt myminion boto_rds.modify_db_instance db_instance_identifier region=us-east-1
+    '''
+    res = __salt__['boto_rds.exists'](name, tags=None, region=region, key=key, keyid=keyid, profile=profile)
+    if not res.get('exists'):
+        return {'modified': False, 'message':
+                'RDS db instance {0} does not exist.'.format(name)}
+
+    try:
+        conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
+        if not conn:
+            return {'modified': False}
+
+        kwargs = {}
+        excluded = {'region', 'key', 'keyid', 'profile', 'name'}
+        keys = set(locals().keys())
+        for key in keys.difference(excluded):
+            val = locals()[key]
+            if val is not None:
+                mapped = boto3_param_map[key]
+                kwargs[mapped[0]] = mapped[1](val)
+
+        info = conn.modify_db_instance(DBInstanceIdentifier=name, **kwargs)
+
+        if not info:
+            return {'modified': bool(info), 'message':
+                    'Failed to modify RDS db instance {0}.'.format(name)}
+
+        return {'modified': bool(info), 'message':
+                'Modified RDS db instance {0}.'.format(name),
+                'results': dict(info)}
+    except ClientError as e:
+        return {'error': salt.utils.boto3.get_error(e)}
+
+
+def _tag_doc(tags):
+    taglist = []
+    if tags is not None:
+        for k, v in six.iteritems(tags):
+            if str(k).startswith('__'):
+                continue
+            taglist.append({'Key': str(k), 'Value': str(v)})
+    return taglist

--- a/extensions/_states/boto_rds.py
+++ b/extensions/_states/boto_rds.py
@@ -1,0 +1,728 @@
+# -*- coding: utf-8 -*-
+'''
+Manage RDSs
+===========
+
+.. versionadded:: 2015.8.0
+
+Create and destroy RDS instances. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses ``boto``, which can be installed via package, or pip.
+
+This module accepts explicit rds credentials but can also utilize
+IAM roles assigned to the instance through Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More information available `here
+<http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html>`_.
+
+If IAM roles are not used you need to specify them either in a pillar file or
+in the minion's config file:
+
+.. code-block:: yaml
+
+    rds.keyid: GKTADJGHEIQSXMKKRBJ08H
+    rds.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify ``key``, ``keyid`` and ``region`` via a profile,
+either passed in as a dict, or as a string to pull from pillars or minion
+config:
+
+.. code-block:: yaml
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure myrds RDS exists:
+      boto_rds.present:
+        - name: myrds
+        - allocated_storage: 5
+        - storage_type: standard
+        - db_instance_class: db.t2.micro
+        - engine: MySQL
+        - master_username: myuser
+        - master_user_password: mypass
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        - tags:
+          -
+            - key1
+            - value1
+          -
+            - key2
+            - value2
+
+.. code-block:: yaml
+
+    Ensure parameter group exists:
+        create-parameter-group:
+          boto_rds.parameter_present:
+            - name: myparametergroup
+            - db_parameter_group_family: mysql5.6
+            - description: "parameter group family"
+            - parameters:
+              - binlog_cache_size: 32768
+              - binlog_checksum: CRC32
+            - region: eu-west-1
+.. note::
+
+:depends: boto3
+
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+import logging
+import os
+
+# Import Salt Libs
+from salt.exceptions import SaltInvocationError
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    if 'boto_rds.exists' in __salt__:
+        return 'boto_rds'
+    return(False, __salt__.missing_fun_string('boto_rds.exists'))
+
+
+def present(name,
+            allocated_storage,
+            db_instance_class,
+            engine,
+            master_username,
+            master_user_password,
+            db_name=None,
+            storage_type=None,
+            db_security_groups=None,
+            vpc_security_group_ids=None,
+            availability_zone=None,
+            db_subnet_group_name=None,
+            preferred_maintenance_window=None,
+            db_parameter_group_name=None,
+            db_cluster_identifier=None,
+            tde_credential_arn=None,
+            tde_credential_password=None,
+            storage_encrypted=None,
+            kms_keyid=None,
+            backup_retention_period=None,
+            preferred_backup_window=None,
+            port=None,
+            multi_az=None,
+            engine_version=None,
+            auto_minor_version_upgrade=None,
+            license_model=None,
+            iops=None,
+            option_group_name=None,
+            character_set_name=None,
+            publicly_accessible=None,
+            wait_status=None,
+            tags=None,
+            copy_tags_to_snapshot=None,
+            region=None,
+            domain=None,
+            key=None,
+            keyid=None,
+            monitoring_interval=None,
+            monitoring_role_arn=None,
+            domain_iam_role_name=None,
+            promotion_tier=None,
+            profile=None):
+    '''
+    Ensure RDS instance exists.
+
+    name
+        Name of the RDS state definition.
+
+    allocated_storage
+        The amount of storage (in gigabytes) to be initially allocated for the
+        database instance.
+
+    db_instance_class
+        The compute and memory capacity of the Amazon RDS DB instance.
+
+    engine
+        The name of the database engine to be used for this instance. Supported
+        engine types are: MySQL, mariadb, oracle-se1, oracle-se, oracle-ee, sqlserver-ee,
+        sqlserver-se, sqlserver-ex, sqlserver-web, postgres and aurora. For more
+        information, please see the ``engine`` argument in the Boto3 RDS
+        `create_db_instance`_ documentation.
+
+    master_username
+        The name of master user for the client DB instance.
+
+    master_user_password
+        The password for the master database user. Can be any printable ASCII
+        character except "/", '"', or "@".
+
+    db_name
+        The meaning of this parameter differs according to the database engine you use.
+        See the Boto3 RDS documentation to determine the appropriate value for your configuration.
+        https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
+
+    storage_type
+        Specifies the storage type to be associated with the DB instance.
+        Options are standard, gp2 and io1. If you specify io1, you must also include
+        a value for the Iops parameter.
+
+    db_security_groups
+        A list of DB security groups to associate with this DB instance.
+
+    vpc_security_group_ids
+        A list of EC2 VPC security groups to associate with this DB instance.
+
+    availability_zone
+        The EC2 Availability Zone that the database instance will be created
+        in.
+
+    db_subnet_group_name
+        A DB subnet group to associate with this DB instance.
+
+    preferred_maintenance_window
+        The weekly time range (in UTC) during which system maintenance can
+        occur.
+
+    db_parameter_group_name
+        A DB parameter group to associate with this DB instance.
+
+    db_cluster_identifier
+        If the DB instance is a member of a DB cluster, contains the name of
+        the DB cluster that the DB instance is a member of.
+
+    tde_credential_arn
+        The ARN from the Key Store with which the instance is associated for
+        TDE encryption.
+
+    tde_credential_password
+        The password to use for TDE encryption if an encryption key is not used.
+
+    storage_encrypted
+        Specifies whether the DB instance is encrypted.
+
+    kms_keyid
+        If storage_encrypted is true, the KMS key identifier for the encrypted
+        DB instance.
+
+    backup_retention_period
+        The number of days for which automated backups are retained.
+
+    preferred_backup_window
+        The daily time range during which automated backups are created if
+        automated backups are enabled.
+
+    port
+        The port number on which the database accepts connections.
+
+    multi_az
+        Specifies if the DB instance is a Multi-AZ deployment. You cannot set
+        the AvailabilityZone parameter if the MultiAZ parameter is set to true.
+
+    engine_version
+        The version number of the database engine to use.
+
+    auto_minor_version_upgrade
+        Indicates that minor engine upgrades will be applied automatically to
+        the DB instance during the maintenance window.
+
+    license_model
+        License model information for this DB instance.
+
+    iops
+        The amount of Provisioned IOPS (input/output operations per second) to
+        be initially allocated for the DB instance.
+
+    option_group_name
+        Indicates that the DB instance should be associated with the specified
+        option group.
+
+    character_set_name
+        For supported engines, indicates that the DB instance should be
+        associated with the specified CharacterSet.
+
+    publicly_accessible
+        Specifies the accessibility options for the DB instance. A value of
+        true specifies an Internet-facing instance with a publicly resolvable
+        DNS name, which resolves to a public IP address. A value of false
+        specifies an internal instance with a DNS name that resolves to a
+        private IP address.
+
+    wait_status
+        Wait for the RDS instance to reach a desired status before finishing
+        the state. Available states: available, modifying, backing-up
+
+    tags
+        A list of tags.
+
+    copy_tags_to_snapshot
+        Specifies whether tags are copied from the DB instance to snapshots of
+        the DB instance.
+
+    region
+        Region to connect to.
+
+    domain
+        The identifier of the Active Directory Domain.
+
+    key
+        AWS secret key to be used.
+
+    keyid
+        AWS access key to be used.
+
+    monitoring_interval
+        The interval, in seconds, between points when Enhanced Monitoring
+        metrics are collected for the DB instance.
+
+    monitoring_role_arn
+        The ARN for the IAM role that permits RDS to send Enhanced Monitoring
+        metrics to CloudWatch Logs.
+
+    domain_iam_role_name
+        Specify the name of the IAM role to be used when making API calls to
+        the Directory Service.
+
+    promotion_tier
+        A value that specifies the order in which an Aurora Replica is
+        promoted to the primary instance after a failure of the existing
+        primary instance. For more information, see Fault Tolerance for an
+        Aurora DB Cluster .
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+
+    .. _create_dbinstance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    r = __salt__['boto_rds.exists'](name, region, key, keyid, profile)
+
+    if not r.get('exists'):
+        if __opts__['test']:
+            ret['comment'] = 'RDS instance {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+
+        r = __salt__['boto_rds.create'](name, allocated_storage,
+                                        db_instance_class, engine,
+                                        master_username,
+                                        master_user_password,
+                                        db_name, db_security_groups,
+                                        vpc_security_group_ids,
+                                        availability_zone,
+                                        db_subnet_group_name,
+                                        preferred_maintenance_window,
+                                        db_parameter_group_name,
+                                        backup_retention_period,
+                                        preferred_backup_window,
+                                        port, multi_az, engine_version,
+                                        auto_minor_version_upgrade,
+                                        license_model, iops,
+                                        option_group_name,
+                                        character_set_name,
+                                        publicly_accessible, wait_status,
+                                        tags, db_cluster_identifier,
+                                        storage_type, tde_credential_arn,
+                                        tde_credential_password,
+                                        storage_encrypted, kms_keyid,
+                                        domain, copy_tags_to_snapshot,
+                                        monitoring_interval,
+                                        monitoring_role_arn,
+                                        domain_iam_role_name, region,
+                                        promotion_tier, key, keyid, profile)
+
+        if not r.get('created'):
+            ret['result'] = False
+            ret['comment'] = 'Failed to create RDS instance {0}.'.format(r['error']['message'])
+            return ret
+
+        _describe = __salt__['boto_rds.describe'](name, region, key, keyid, profile)
+        ret['changes']['old'] = {'instance': None}
+        ret['changes']['new'] = _describe
+        ret['comment'] = 'RDS instance {0} created.'.format(name)
+    else:
+        ret['comment'] = 'RDS instance {0} exists.'.format(name)
+    return ret
+
+
+def replica_present(name, source, db_instance_class=None,
+                    availability_zone=None, port=None,
+                    auto_minor_version_upgrade=None, iops=None,
+                    option_group_name=None, publicly_accessible=None,
+                    tags=None, region=None, key=None, keyid=None,
+                    profile=None, db_parameter_group_name=None):
+    '''
+    Ensure RDS replica exists.
+
+    .. code-block:: yaml
+
+        Ensure myrds replica RDS exists:
+          boto_rds.create_replica:
+            - name: myreplica
+            - source: mydb
+    '''
+    ret = {'name': name,
+           'result': None,
+           'comment': '',
+           'changes': {}
+           }
+    replica_exists = __salt__['boto_rds.exists'](name, tags, region, key,
+                                                 keyid, profile)
+    if not replica_exists:
+        if __opts__['test']:
+            ret['comment'] = 'RDS read replica {0} is set to be created '.format(name)
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_rds.create_read_replica'](name, source,
+                                                           db_instance_class,
+                                                           availability_zone, port,
+                                                           auto_minor_version_upgrade,
+                                                           iops, option_group_name,
+                                                           publicly_accessible,
+                                                           tags, region, key,
+                                                           keyid, profile)
+        if created:
+            config = __salt__['boto_rds.describe'](name, tags, region,
+                                                   key, keyid, profile)
+            ret['result'] = True
+            ret['comment'] = 'RDS replica {0} created.'.format(name)
+            ret['changes']['old'] = None
+            ret['changes']['new'] = config
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create RDS replica {0}.'.format(name)
+    else:
+        _describe = __salt__['boto_rds.describe'](name, tags, region, key,
+                                                  keyid, profile)
+        if db_parameter_group_name is not None and _describe['db_parameter_groups'][0]['DBParameterGroupName'] != db_parameter_group_name:
+            modified = __salt__['boto_rds.modify_db_instance'](name, db_parameter_group_name=db_parameter_group_name, region=region,
+                                                               key=key, keyid=keyid, profile=profile)
+            if not modified:
+                ret['result'] = False
+                ret['comment'] = 'Failed to update parameter group of {0} RDS instance.'.format(name)
+            ret['changes']['old'] = _describe['db_parameter_groups'][0]['DBParameterGroupName']
+            ret['changes']['new'] = db_parameter_group_name
+        ret['result'] = True
+        ret['comment'] = 'RDS replica {0} exists.'.format(name)
+    return ret
+
+
+def subnet_group_present(name, description, subnet_ids=None, subnet_names=None,
+                         tags=None, region=None, key=None, keyid=None,
+                         profile=None):
+    '''
+    Ensure DB subnet group exists.
+
+    name
+        The name for the DB subnet group. This value is stored as a lowercase string.
+
+    subnet_ids
+        A list of the EC2 Subnet IDs for the DB subnet group.
+        Either subnet_ids or subnet_names must be provided.
+
+    subnet_names
+        A list of The EC2 Subnet names for the DB subnet group.
+        Either subnet_ids or subnet_names must be provided.
+
+    description
+        Subnet group description.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    if not salt.utils.exactly_one((subnet_ids, subnet_names)):
+        raise SaltInvocationError('One (but not both) of subnet_ids or '
+                                  'subnet_names must be provided.')
+
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    if not subnet_ids:
+        subnet_ids = []
+
+    if subnet_names:
+        for i in subnet_names:
+            r = __salt__['boto_vpc.get_resource_id']('subnet', name=i,
+                                                     region=region,
+                                                     key=key, keyid=keyid,
+                                                     profile=profile)
+
+            if 'error' in r:
+                ret['comment'] = 'Error looking up subnet ids: {0}'.format(
+                    r['error']['message'])
+                ret['result'] = False
+                return ret
+            if r['id'] is None:
+                ret['comment'] = 'Subnet {0} does not exist.'.format(i)
+                ret['result'] = False
+                return ret
+            subnet_ids.append(r['id'])
+
+    for i in subnet_ids:
+        r = __salt__['boto_rds.create_subnet_group'](name=name,
+                                                     description=description,
+                                                     subnet_ids=subnet_ids,
+                                                     tags=tags, region=region,
+                                                     key=key, keyid=keyid,
+                                                     profile=profile)
+
+        if not r.get('exists'):
+            if __opts__['test']:
+                ret['comment'] = 'Subnet group {0} is set to be created.'.format(name)
+                ret['result'] = None
+                return ret
+            if not r.get('created'):
+                ret['result'] = False
+                ret['comment'] = 'Failed to create {0} subnet group.'.format(r['error']['message'])
+                return ret
+
+            _describe = __salt__['boto_rds.describe']('subnet',
+                                                      name=i,
+                                                      region=region,
+                                                      key=key,
+                                                      keyid=keyid,
+                                                      profile=profile)
+
+            ret['changes']['old'] = None
+            ret['changes']['new'] = _describe
+            ret['comment'] = 'Subnet {0} created.'.format(name)
+        else:
+            ret['comment'] = 'Subnet {0} present.'.format(name)
+
+        return ret
+
+
+def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
+           tags=None, region=None, key=None, keyid=None, profile=None,
+           wait_for_deletion=True, timeout=180):
+    '''
+    Ensure RDS instance is absent.
+
+    name
+        Name of the RDS instance.
+
+    skip_final_snapshot
+        Whether a final db snapshot is created before the instance is deleted.
+        If True, no snapshot is created.
+        If False, a snapshot is created before deleting the instance.
+
+    final_db_snapshot_identifier
+        If a final snapshot is requested, this is the identifier used for that
+        snapshot.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+
+    .. _create_db_instance: https://boto3.readthedocs.io/en/latest/reference/services/rds.html#RDS.Client.create_db_instance
+
+    wait_for_deletion (bool)
+        Wait for the RDS instance to be deleted completely before finishing
+        the state.
+
+    timeout (in seconds)
+        The amount of time that can pass before raising an Exception.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_rds.exists'](name, tags, region, key, keyid,
+                                         profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} RDS does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'RDS {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    deleted = __salt__['boto_rds.delete'](name, skip_final_snapshot,
+                                          final_db_snapshot_identifier,
+                                          region, key, keyid, profile,
+                                          wait_for_deletion, timeout)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} RDS.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'RDS {0} deleted.'.format(name)
+    return ret
+
+
+def subnet_group_absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+
+    exists = __salt__['boto_rds.subnet_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                      keyid=keyid, profile=profile)
+    if not exists:
+        ret['result'] = True
+        ret['comment'] = '{0} RDS subnet group does not exist.'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['comment'] = 'RDS subnet group {0} is set to be removed.'.format(name)
+        ret['result'] = None
+        return ret
+    deleted = __salt__['boto_rds.delete_subnet_group'](name, region, key, keyid, profile)
+    if not deleted:
+        ret['result'] = False
+        ret['comment'] = 'Failed to delete {0} RDS subnet group.'.format(name)
+        return ret
+    ret['changes']['old'] = name
+    ret['changes']['new'] = None
+    ret['comment'] = 'RDS subnet group {0} deleted.'.format(name)
+    return ret
+
+
+def parameter_present(name, db_parameter_group_family, description, parameters=None,
+                      apply_method="pending-reboot", tags=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure DB parameter group exists and update parameters.
+
+    name
+        The name for the parameter group.
+
+    db_parameter_group_family
+        The DB parameter group family name. A
+        DB parameter group can be associated with one and only one DB
+        parameter group family, and can be applied only to a DB instance
+        running a database engine and engine version compatible with that
+        DB parameter group family.
+
+    description
+        Parameter group description.
+
+    parameters
+        The DB parameters that need to be changed of type dictionary.
+
+    apply_method
+        The `apply-immediate` method can be used only for dynamic
+        parameters; the `pending-reboot` method can be used with MySQL
+        and Oracle DB instances for either dynamic or static
+        parameters. For Microsoft SQL Server DB instances, the
+        `pending-reboot` method can be used only for static
+        parameters.
+
+    tags
+        A list of tags.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name,
+           'result': True,
+           'comment': '',
+           'changes': {}
+           }
+    exists = __salt__['boto_rds.parameter_group_exists'](name=name, tags=tags, region=region, key=key,
+                                                         keyid=keyid, profile=profile)
+    if not exists:
+        if __opts__['test']:
+            ret['comment'] = 'Parameter group {0} is set to be created.'.format(name)
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_rds.create_parameter_group'](name=name, db_parameter_group_family=db_parameter_group_family,
+                                                              description=description, tags=tags, region=region,
+                                                              key=key, keyid=keyid, profile=profile)
+        if not created:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} parameter group.'.format(name)
+            return ret
+        ret['changes']['New Parameter Group'] = name
+        ret['comment'] = 'Parameter group {0} created.'.format(name)
+    else:
+        ret['comment'] = 'Parameter group {0} present.'.format(name)
+    if parameters is not None:
+        params = {}
+        changed = {}
+        for items in parameters:
+            for k, value in items.items():
+                params[k] = value
+        logging.debug('Parameters from user are : {0}.'.format(params))
+        options = __salt__['boto_rds.describe_parameters'](name=name, region=region, key=key, keyid=keyid, profile=profile)
+        if not options:
+            ret['result'] = False
+            ret['comment'] = os.linesep.join([ret['comment'], 'Faled to get parameters for group  {0}.'.format(name)])
+            return ret
+        options = options['DescribeDBParametersResponse']['DescribeDBParametersResult']['Parameters']
+        for values in options:
+            if values['ParameterName'] in params and str(params.get(values['ParameterName'])) != str(values['ParameterValue']):
+                logging.debug('Values that are being compared are {0}:{1} .'.format(params.get(values['ParameterName']), values['ParameterValue']))
+                changed[values['ParameterName']] = params.get(values['ParameterName'])
+        if len(changed) > 0:
+            if __opts__['test']:
+                ret['comment'] = os.linesep.join([ret['comment'], 'Parameters {0} for group {1} are set to be changed.'.format(changed, name)])
+                ret['result'] = None
+                return ret
+            update = __salt__['boto_rds.update_parameter_group'](name, parameters=changed, apply_method=apply_method, tags=tags, region=region,
+                                                                 key=key, keyid=keyid, profile=profile)
+            if not update:
+                ret['result'] = False
+                ret['comment'] = os.linesep.join([ret['comment'], 'Failed to change parameters {0} for group {1}.'.format(changed, name)])
+                return ret
+            ret['changes']['Parameters'] = changed
+            ret['comment'] = os.linesep.join([ret['comment'], 'Parameters {0} for group {1} are changed.'.format(changed, name)])
+        else:
+            ret['comment'] = os.linesep.join([ret['comment'], 'Parameters {0} for group {1} are present.'.format(params, name)])
+    return ret


### PR DESCRIPTION
**Patched version of boto_rds from carbon release**
The boto_rds module in the carbon release branch has a bug preventing
use of multi_az as well as forcing definition of optional
parameters. This commit copies the patched version that I have submitted
upstream for inclusion in the final release. Once that patch has been
adopted this change can be reverted.