### PR TITLE
Added functionality to detach_volume

### DIFF
--- a/extensions/_modules/boto_ec2.py
+++ b/extensions/_modules/boto_ec2.py
@@ -1896,7 +1896,7 @@ def delete_tags(resource_ids, tags, region=None, key=None, keyid=None, profile=N
 
 
 def detach_volume(volume_id, instance_id=None, device=None, force=False,
-                  region=None, key=None, keyid=None, profile=None, volume_name=None):
+                  region=None, key=None, keyid=None, profile=None, tags=None):
     '''
     Detach an EBS volume from an EC2 instance.
 
@@ -1904,8 +1904,8 @@ def detach_volume(volume_id, instance_id=None, device=None, force=False,
 
     volume_id
         (string) – The ID of the EBS volume to be detached.
-    volume_name
-        (string) - The name of the EBS volume to be detached.
+    tags
+        (dict) - The tag(s) of the EBS volume to be detached.
     instance_id
         (string) – The ID of the EC2 instance from which it will be detached.
     device
@@ -1925,21 +1925,19 @@ def detach_volume(volume_id, instance_id=None, device=None, force=False,
     .. code-block:: bash
 
         salt-call boto_ec2.detach_volume vol-12345678 i-87654321
-        salt-call boto_ec2.detach_volume myvolume
+        salt-call boto_ec2.detach_volume tags='{"name":"myvolume"}'
 
     '''
     conn = _get_conn(region=region, key=key, keyid=keyid, profile=profile)
     if volume_id:
-    try:
-        return conn.detach_volume(volume_id, instance_id, device, force)
-    except boto.exception.BotoServerError as e:
-        log.error(e)
-        return False
-    elif volume_name:
         try:
-            volumes = conn.describe_volumes(Filters = [
-                                    {'Name': 'name',
-                                    'Values': [volume_name, ]}])
+            return conn.detach_volume(volume_id, instance_id, device, force)
+        except boto.exception.BotoServerError as e:
+            log.error(e)
+            return False
+    elif tags:
+        try:
+            volumes = conn.describe_volumes(Filters = [{'Name': tag_name, 'Values':[tag_value]} for tag_name, tag_value in tags.items()])
             for volume in volumes['Volumes']:
                 volume_id = volume['VolumeId']
                 return conn.detach_volume(volume_id, instance_id, device, force)
@@ -1947,7 +1945,7 @@ def detach_volume(volume_id, instance_id=None, device=None, force=False,
             log.error(e)
             return False
     else:
-        msg = "No volume_id or volume_name provided."
+        msg = "No volume_id or tag provided."
         raise CommandExecutionError(msg)
         return False
 


### PR DESCRIPTION
detach_volume requires the volume_id to work, however we need to be able to only pass the volume_name as the volume_id might not be known by salt-master.
This change calls describe_volumes using the volume_name and then iterates over volume_id and passes the value to detach_volume.