### PR TITLE
Heroku state to manage config vars through salt pillar data

### DIFF
--- a/extensions/_modules/heroku.py
+++ b/extensions/_modules/heroku.py
@@ -74,6 +74,7 @@ def _query(api_key=None, endpoint=None, arguments=None, method='GET', data=None)
     api_url = 'https://api.heroku.com'  # default API URL
     url = _urljoin(api_url, endpoint)
     if arguments:
+        url = url + '/'
         url = _urljoin(url, arguments)
 
     if endpoint:
@@ -137,7 +138,7 @@ def app_info(app_name, api_key = None):
     https://devcenter.heroku.com/articles/platform-api-reference#app-info
 
     CLI Example:
-    salt-call heroku.app_info
+    salt-call heroku.app_info <app_name>
     '''
 
     result = _query(endpoint='apps', arguments = app_name, api_key = api_key)
@@ -150,7 +151,7 @@ def list_app_addons(app_name, api_key = None):
     https://devcenter.heroku.com/articles/platform-api-reference#add-on-list-by-app
 
     CLI Examples:
-    salt-call heroku.list_app_addons
+    salt-call heroku.list_app_addons <app_name>
     '''
 
     result = _query(endpoint='apps',
@@ -165,7 +166,7 @@ def list_app_attachments(app_name, api_key = None):
     https://devcenter.heroku.com/articles/platform-api-reference#add-on-attachment-list
 
     CLI Examples:
-    salt-call heroku.list_app_attachments
+    salt-call heroku.list_app_attachments <app_name>
     '''
 
     result = _query(endpoint='apps',
@@ -180,7 +181,7 @@ def list_app_buildpacks(app_name, api_key = None):
     https://devcenter.heroku.com/articles/platform-api-reference#buildpack-installations-list
 
     CLI Examples:
-    salt-call heroku.list_app_buildpacks
+    salt-call heroku.list_app_buildpacks <app_name>
     '''
 
     result = _query(endpoint='apps',
@@ -195,7 +196,7 @@ def list_app_config_vars(app_name, api_key = None):
     https://devcenter.heroku.com/articles/platform-api-reference#config-vars
 
     CLI Examples:
-    salt-call heroku.list_app_config_vars
+    salt-call heroku.list_app_config_vars <app_name>
     '''
     result = _query(endpoint='apps',
                arguments=app_name+'/config-vars',
@@ -210,10 +211,10 @@ def update_app_config_vars(app_name, vars, api_key = None):
 
     CLI Examples:
     - Set/Modify config variable:
-      salt-call heroku.update_config_vars data='{"name":"value"}'
+      salt-call heroku.update_config_vars <app_name> data='{"name":"value"}'
 
     - Delete config variable:
-      salt-call heroku.update_config_vars data='{"name":null}'
+      salt-call heroku.update_config_vars <app_name> data='{"name":null}'
     '''
     result = _query(endpoint='apps',
                arguments=app_name+'/config-vars',
@@ -232,7 +233,7 @@ def list_app_dynos(app_name, api_key=None):
     https://devcenter.heroku.com/articles/platform-api-reference#dyno-list
 
     CLI Examples:
-    salt-call heroku.list_app_dynos
+    salt-call heroku.list_app_dynos <app_name>
     '''
     result = _query(endpoint = 'apps', arguments = app_name+'/dynos', api_key = api_key)
     log.debug('result {0}'.format(result))
@@ -244,7 +245,7 @@ def restart_app_dynos(app_name, api_key=None):
     https://devcenter.heroku.com/articles/platform-api-reference#dyno-restart-all
 
     CLI Examples:
-    salt-call heroku.restart_app_dynos
+    salt-call heroku.restart_app_dynos <app_name>
     '''
     result = _query(endpoint = 'apps', arguments = app_name+'/dynos', method = 'DELETE', api_key = api_key)
     log.debug('result {0}'.format(result))

--- a/extensions/_states/heroku.py
+++ b/extensions/_states/heroku.py
@@ -2,8 +2,6 @@
 '''
 State for managing heroku apps.
 
-.. versionadded:: 2015.5.0
-
 :configuration: This state can be used by either passing an api key directly
     or by specifying it in a configuration profile in pillar.
 
@@ -22,10 +20,6 @@ import logging
 
 import sys
 import salt.config
-import salt.exceptions
-import salt.ext.six.moves.http_client
-import salt.syspaths
-import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -48,7 +42,7 @@ def __virtual__():
     return True
 
 
-def diff_app_config_vars(name, config_vars, api_key):
+def _diff_app_config_vars(name, config_vars, api_key):
     '''
     Compare keys and values between Heroku and Pillar config vars.
     This function makes no changes to Heroku config vars and only
@@ -134,7 +128,7 @@ def update_app_config_vars(name, config_vars, api_key):
            'result': True,
            'changes': {}}
 
-    diff_app_config_vars(name, config_vars, api_key)
+    _diff_app_config_vars(name, config_vars, api_key)
     if any(v for v in diff_heroku_pillar_dict.values()):
         __salt__['heroku.update_app_config_vars'](name, config_vars, api_key)
         new_app_config_vars = __salt__['heroku.list_app_config_vars'](name, api_key)

--- a/extensions/_states/heroku.py
+++ b/extensions/_states/heroku.py
@@ -1,0 +1,181 @@
+# -*- coding: utf-8 -*-
+'''
+State for managing heroku apps.
+
+.. versionadded:: 2015.5.0
+
+:configuration: This state can be used by either passing an api key directly
+    or by specifying it in a configuration profile in pillar.
+
+    It is possible to use a different API than http://api.heroku.com,
+    by specifying the API URL in config as api_url, or by passing the value directly.
+
+    For example:
+
+    .. code-block:: yaml
+
+        heroku.<name_of_state>:
+          - api_key: peWcBiMOS9HrZG15peWcBiMOS9HrZG15
+'''
+from __future__ import absolute_import
+import logging
+
+import sys
+import salt.config
+import salt.exceptions
+import salt.ext.six.moves.http_client
+import salt.syspaths
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+# Global keys to maintain state of dict mismatch between Heroku and Pillar
+diff_heroku_pillar_dict = {'key_or_value_mismatch': False,
+                           'heroku_not_pillar': False,
+                           'pillar_not_heroku': False}
+
+# Global dicts to store diffs between Heroku and Pillar config vars
+heroku_diff_dict = {}
+pillar_diff_dict = {}
+
+
+def __virtual__():
+    '''
+    Return virtual name of the module.
+
+    :return: The virtual name of the module.
+    '''
+    return True
+
+
+def diff_app_config_vars(name, config_vars, api_key):
+    '''
+    Compare keys and values between Heroku and Pillar config vars.
+    This function makes no changes to Heroku config vars and only
+    lists differences.
+
+    :param name: The name of the Heroku app
+    :param config_vars: The config_vars specified in pillar
+    :param api_key: The Heroku api_key
+    :returns: Result of executing the state
+    :rtype: dict
+    '''
+
+    ret = {'name': name,
+           'comment': '',
+           'result': None,
+           'changes': {}}
+
+    try:
+        app_config_vars = __salt__['heroku.list_app_config_vars'](name, api_key)
+        log.debug("Calling _diff_heroku_pillar_vars")
+        _diff_heroku_pillar_vars(app_config_vars, config_vars)
+        if all(not v for v in diff_heroku_pillar_dict.values()):
+            ret['result'] = True
+            ret['comment'] = 'No changes detected'
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Pillar and Heroku mismatch'
+            ret['changes'] = {'old': {'heroku': heroku_diff_dict, 'pillar': pillar_diff_dict}}
+    except:
+        e = sys.exc_info()[0]
+        ret['result'] = False
+        log.exception(e)
+
+    return ret
+
+
+def _diff_heroku_pillar_vars(app_config_vars, config_vars):
+    '''
+    Internal function that runs multiple set operations on Heroku and Pillar
+    dicts and sets the values on diff_heroku_pillar_dict accordingly
+
+    :param app_config_vars: The Heroku configuration variables
+    :param config_vars: The Pillar configuration variables
+    :returns: three global dicts
+    '''
+
+
+    global diff_heroku_pillar_dict, heroku_diff_dict, pillar_diff_dict
+    app_config_vars_set = set(app_config_vars.items())
+    config_vars_set = set(config_vars.items())
+
+    if app_config_vars_set.symmetric_difference(config_vars_set):
+        diff_heroku_pillar_dict['key_or_value_mismatch'] = True
+        heroku_diff_dict = dict(app_config_vars_set.difference(config_vars_set))
+        pillar_diff_dict = dict(config_vars_set.difference(app_config_vars_set))
+    if len(app_config_vars) - len(config_vars) > 0:
+        diff_heroku_pillar_dict['heroku_not_pillar'] = True
+    if len(app_config_vars) - len(config_vars) < 0:
+        diff_heroku_pillar_dict['pillar_not_heroku'] = True
+
+    log.debug("Completed _diff_heroku_pillar_vars")
+    return diff_heroku_pillar_dict, heroku_diff_dict, pillar_diff_dict
+
+
+def update_app_config_vars(name, config_vars, api_key):
+    '''
+    Update Heroku config vars based on specified pillar config vars.
+    This function will perform the following actions:
+      - Change Heroku config var values for the keys that match one in pillar
+      - Add keys from pillar to Heroku
+      - Leave Heroku keys not find in pillar unchanged
+
+    :param name: The name of the Heroku app
+    :param config_vars: The config_vars specified in pillar
+    :param api_key: The Heroku api_key
+    :returns: Result of executing the state
+    :rtype: dict
+    '''
+
+
+    ret = {'name': name,
+           'comment': '',
+           'result': True,
+           'changes': {}}
+
+    diff_app_config_vars(name, config_vars, api_key)
+    if any(v for v in diff_heroku_pillar_dict.values()):
+        __salt__['heroku.update_app_config_vars'](name, config_vars, api_key)
+        new_app_config_vars = __salt__['heroku.list_app_config_vars'](name, api_key)
+        ret['changes']['new'] = {'heroku': new_app_config_vars}
+    return ret
+
+def override_app_config_vars(name, config_vars, api_key):
+    '''
+    * WARNING * Destructive Function
+    This function will delete all Heroku config var keys and values and
+    replace them with ones specified in pillar
+
+    :param name: The name of the Heroku app
+    :param config_vars: The config_vars specified in pillar
+    :param api_key: The Heroku api_key
+    :returns: Result of executing the state
+    :rtype: dict
+    '''
+
+
+    ret = {'name': name,
+           'comment': 'Heroku config variables have been overwritten',
+           'result': True,
+           'changes': {}}
+
+    try:
+        app_config_vars = __salt__['heroku.list_app_config_vars'](name, api_key)
+        empty_values = dict.fromkeys(app_config_vars)
+        for key, value in empty_values.items():
+            if value is None:
+                values = ''
+                empty_values[key] = value
+
+        log.debug("Created empty_dict")
+        __salt__['heroku.update_app_config_vars'](name, empty_values, api_key)
+        __salt__['heroku.update_app_config_vars'](name, config_vars, api_key)
+        ret['changes']['old'] = {'heroku': app_config_vars}
+        ret['changes']['new'] = {'heroku': config_vars}
+    except:
+        e = sys.exc_info()[0]
+        ret['result'] = False
+        log.exception(e)
+
+    return ret


### PR DESCRIPTION
Created a Heroku state to manage config vars through Salt with three main functions:
- Compare config vars in Heroku to pillar data
- Update Heroku config vars from pillar data 
- Replace all Heroku config vars from pillar data

This extension relies on running salt-proxies to handle the request from the salt-master and render the pillar on the "minion". Additionally, the current limitation is that the values of the config_vars specified in pillar need to be strings as that it what Heroku stores its values as.

The other minor change was in the heroku modules where I noticed that the examples listed omitted the `app_name` and thus might be confusing to someone potentially using that module.