### PR TITLE
Fix deprecated get_backend() call

### DIFF
--- a/extensions/_modules/testinframod.py
+++ b/extensions/_modules/testinframod.py
@@ -50,7 +50,7 @@ def _get_module(module_name, backend=default_backend):
     :rtype: object
 
     """
-    backend_instance = testinfra.get_backend(backend)
+    backend_instance = testinfra.backend.get_backend(backend)
     return backend_instance.get_module(_to_pascal_case(module_name))
 
 


### PR DESCRIPTION
Replace call to testinfra.get_backend() with
testinfra.backend.get_backend(). The former is deprecated as of
release 2.0.0 of testinfra. The new syntax is backwards-compatible.